### PR TITLE
Support inso 11.1.0+

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,10 @@ async function action() {
   let arch = getArch();
   let compression = getCompression(process.platform);
 
+  const targetVersion = "11.1.0"
+
   if (os == "linux") {
-    if (semver.lte(semverVersion, "11.1.0")) {
+    if (semver.lte(semverVersion, targetVersion)) {
       os = os + "-" + arch;
     }
   }
@@ -28,7 +30,9 @@ async function action() {
   let insoDirectory = tc.find("inso", fullVersion);
   if (!insoDirectory) {
     if (os == "linux") {
-      os = os + "-" + arch;
+      if (semver.lte(semverVersion, targetVersion)) {
+        os = os + "-" + arch;
+      }
     }
     const versionUrl = `https://github.com/Kong/insomnia/releases/download/core%40${semverVersion}/inso-${fullVersion}.${compression}`;
     const insoPath = await tc.downloadTool(versionUrl);

--- a/index.js
+++ b/index.js
@@ -17,7 +17,9 @@ async function action() {
   let compression = getCompression(process.platform);
 
   if (os == "linux") {
-    os = os + "-" + arch;
+    if (semver.lte(semverVersion, "11.1.0")) {
+      os = os + "-" + arch;
+    }
   }
 
   const fullVersion = `${os}-${semverVersion}`;

--- a/index.test.js
+++ b/index.test.js
@@ -32,6 +32,7 @@ describe("version parsing", () => {
     ["1.7.0", "linux-x64-1.7.0"],
     ["1.6.4", "linux-x64-1.6.4"],
     ["1.8.0-beta2", "linux-x64-1.8.0-beta2"],
+    ["11.2.0", "linux-11.2.0"]
   ];
 
   test.each(cases)(


### PR DESCRIPTION
## overview

The `setup-inso` failed to download binaries for specific versions(11.1.0 +) due to a release name change from the discontinuation of the `inso` Linux ARM64 build. To address this, a conditional branch was added to differentiate names for Linux versions above a certain threshold.